### PR TITLE
[FIX] notify_mail_private method

### DIFF
--- a/mail_private/i18n/es.po
+++ b/mail_private/i18n/es.po
@@ -1,0 +1,70 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* mail_private
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-05-06 09:30+0000\n"
+"PO-Revision-Date: 2019-05-06 11:32+0200\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#. module: mail_private
+#: model:ir.model,name:mail_private.model_mail_compose_message
+msgid "Email composition wizard"
+msgstr "Asistente composición Correo Electrónico"
+
+#. module: mail_private
+#: model:ir.model,name:mail_private.model_mail_message
+msgid "Message"
+msgstr "Mensaje"
+
+#. module: mail_private
+#: model:ir.model.fields,field_description:mail_private.field_mail_compose_message_is_private
+#: model:ir.model.fields,field_description:mail_private.field_mail_mail_is_private
+#: model:ir.model.fields,field_description:mail_private.field_mail_message_is_private
+msgid "Send Internal Message"
+msgstr "Enviar Mensaje Interno"
+
+#. module: mail_private
+#. openerp-web
+#: code:addons/mail_private/static/src/xml/mail_private.xml:6
+#, python-format
+msgid "Send a message to specified recipients only"
+msgstr "Enviar mensaje sólo a los destinatarios seleccionados"
+
+#. module: mail_private
+#. openerp-web
+#: code:addons/mail_private/static/src/xml/mail_private.xml:6
+#, python-format
+msgid "Send internal message"
+msgstr "Enviar mensaje interno"
+
+#. module: mail_private
+#. openerp-web
+#: code:addons/mail_private/static/src/xml/mail_private.xml:12
+#, python-format
+msgid "To: Followers of"
+msgstr "Para: Seguidores del"
+
+#. module: mail_private
+#. openerp-web
+#: code:addons/mail_private/static/src/xml/mail_private.xml:23
+#, python-format
+msgid "Uncheck all"
+msgstr "Desmarcar todos"
+
+#. module: mail_private
+#. openerp-web
+#: code:addons/mail_private/static/src/xml/mail_private.xml:17
+#, python-format
+msgid "this document"
+msgstr "este documento"

--- a/mail_private/models.py
+++ b/mail_private/models.py
@@ -88,7 +88,7 @@ class MailMessage(models.Model):
 
         # notify partners and channels
         # those methods are called as SUPERUSER because portal users posting messages
-        # have no access to partner model. Maybe propagating a real uid could be necessary.
+        # have no access to partner model. Maybe propagating a real uid could be necessary. 
         email_channels = channels_sudo.filtered(lambda channel: channel.email_send)
         notif_partners = partners_sudo.filtered(lambda partner: 'inbox' in partner.mapped('user_ids.notification_type'))
         if email_channels or partners_sudo - notif_partners:
@@ -99,6 +99,11 @@ class MailMessage(models.Model):
                 ('email', '!=', self_sudo.author_id.email or self_sudo.email_from),
             ])._notify(self, force_send=force_send, send_after_commit=send_after_commit, user_signature=user_signature)
         channels_sudo._notify(self)
+        
+        # (OS8A)[FIX] Add the next line to send private mails.
+        # In the previous "if" conditional. 
+        # If the recipient is the only one, the message is not sent.
+        notif_partners._notify_by_chat(self)
 
         # Discard cache, because child / parent allow reading and therefore
         # change access rights.

--- a/mail_private/models.py
+++ b/mail_private/models.py
@@ -88,7 +88,7 @@ class MailMessage(models.Model):
 
         # notify partners and channels
         # those methods are called as SUPERUSER because portal users posting messages
-        # have no access to partner model. Maybe propagating a real uid could be necessary. 
+        # have no access to partner model. Maybe propagating a real uid could be necessary.
         email_channels = channels_sudo.filtered(lambda channel: channel.email_send)
         notif_partners = partners_sudo.filtered(lambda partner: 'inbox' in partner.mapped('user_ids.notification_type'))
         if email_channels or partners_sudo - notif_partners:
@@ -99,10 +99,11 @@ class MailMessage(models.Model):
                 ('email', '!=', self_sudo.author_id.email or self_sudo.email_from),
             ])._notify(self, force_send=force_send, send_after_commit=send_after_commit, user_signature=user_signature)
         channels_sudo._notify(self)
-        
-        # (OS8A)[FIX] Add the next line to send private mails.
-        # In the previous "if" conditional. 
-        # If the recipient is the only one, the message is not sent.
+
+        # REVIEW:
+        # In the previous IF conditional
+        # "if email_channels or partners_sudo - notif_partners:"
+        # If the recipient is the only one, the message is not sent with longpolling.
         notif_partners._notify_by_chat(self)
 
         # Discard cache, because child / parent allow reading and therefore


### PR DESCRIPTION
In the previous "if" conditional.
If the recipient is the only one, the message is not sent.

(OS8A)[FIX] Add the next line to send private mails.
notif_partners._notify_by_chat(self)

PD: @DarioLodeiros mira este PR para hacerle a It-projects si lo ves bien.